### PR TITLE
feat: add brightness and saturation adjustment methods

### DIFF
--- a/API.md
+++ b/API.md
@@ -12,6 +12,8 @@ Complete API documentation for Colority's facades, classes, and methods.
 | **Create from HSL** | `fromHsl()` | `colority()->fromHsl([180, 50, 50])` |
 | **Create from OKLCH** | `fromOklch()` | `colority()->fromOklch([0.70, 0.11, 163])` |
 | **Convert formats** | `toHex()`, `toRgb()`, `toHsl()`, `toOklch()` | `$color->toHex()` |
+| **Adjust brightness** | `lighter()`, `darker()` | `$color->lighter()->toHex()` |
+| **Adjust saturation** | `saturate()`, `desaturate()` | `$color->saturate()` |
 | **Generate from text** | `textToColor()` | `colority()->textToColor('username')` |
 | **Best contrast color** | `getBestForegroundColor()` | `$bg->getBestForegroundColor()` |
 | **Get contrast ratio** | `getContrastRatio()` | `$color->getContrastRatio($other)` |
@@ -263,6 +265,35 @@ $equal = $hex->isEqualTo($rgb); // true
 
 // Luminance
 $luminance = $hex->getLuminance(); // returns float between 0.0 and 1.0
+```
+
+#### Color Adjustment Methods
+
+```php
+// Adjust lightness (brightness)
+$color->adjustLightness(float $percent): HslColor // +- percentage
+$color->lighter(float $amount = 10): HslColor // Increase lightness
+$color->darker(float $amount = 10): HslColor // Decrease lightness
+
+// Adjust saturation
+$color->adjustSaturation(float $percent): HslColor // +- percentage
+$color->saturate(float $amount = 10): HslColor // Increase saturation
+$color->desaturate(float $amount = 10): HslColor // Decrease saturation
+```
+
+**Example:**
+```php
+$hex = Colority::fromHex('#3498db');
+
+// All methods return HslColor - chain with conversion as needed
+$lighter = $hex->lighter()->toHex(); // Brighter HexColor
+$darker = $hex->darker(20)->toRgb(); // 20% darker as RgbColor
+$vivid = $hex->saturate()->toHsl(); // More saturated HslColor
+$muted = $hex->desaturate(30); // 30% less saturated
+
+// Direct adjustments
+$adjusted = $hex->adjustLightness(-15); // 15% darker
+$adjusted = $hex->adjustSaturation(25); // 25% more saturated
 ```
 
 #### Contrast & Accessibility Methods

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@
 
 ### Color Utilities
 
+- **[Color Adjustments](#color-adjustments)**: Adjust brightness and saturation
 - **[getImageMostCommonColor](#getimagemostcommoncolor)**: Get the single most common color in an image
 - **[getImageColors](#getimagecolors)**: Extract representative colors from images using K-Means clustering
 - **[getImageDominantColors](#getimagedominantcolors)**: Extract dominant colors by pixel frequency with metadata
@@ -333,6 +334,32 @@ $oklchColor = $hexColor->toOklch();
 ---
 
 ### Color utilities
+
+#### Color Adjustments
+
+Adjust the brightness (lightness) and saturation of any color. All methods return an `HslColor` that you can convert as needed.
+
+```php
+$color = colority()->fromHex('#3498db');
+
+// Adjust brightness
+$color->lighter(); // 10% brighter (default)
+$color->lighter(20); // 20% brighter
+$color->darker(); // 10% darker (default)
+$color->darker(15); // 15% darker
+
+// Adjust saturation
+$color->saturate(); // 10% more saturated
+$color->desaturate(25); // 25% less saturated
+
+// Direct adjustment (positive or negative)
+$color->adjustLightness(30); // +30% lightness
+$color->adjustSaturation(-20); // -20% saturation
+
+// Convert result to any format
+$color->lighter()->toHex(); // Get as HexColor
+$color->darker()->toRgb(); // Get as RgbColor
+```
 
 #### getImageMostCommonColor
 

--- a/src/Colors/Color.php
+++ b/src/Colors/Color.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tomloprod\Colority\Colors;
 
+use Tomloprod\Colority\Concerns\AdjustsColorValues;
 use Tomloprod\Colority\Concerns\ResolvesContrastRatioColor;
 use Tomloprod\Colority\Contracts\TransformableColor;
 use Tomloprod\Colority\Contracts\ValueColorParser;
@@ -11,6 +12,7 @@ use Tomloprod\Colority\Support\Algorithms\LuminosityContrastRatio;
 
 abstract class Color implements TransformableColor
 {
+    use AdjustsColorValues;
     use ResolvesContrastRatioColor;
 
     protected string $valueColor;

--- a/src/Concerns/AdjustsColorValues.php
+++ b/src/Concerns/AdjustsColorValues.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tomloprod\Colority\Concerns;
+
+use Tomloprod\Colority\Colors\HslColor;
+
+trait AdjustsColorValues
+{
+    /**
+     * Adjust the lightness by a percentage.
+     *
+     * @param  float  $percent  Positive to brighten, negative to darken.
+     */
+    public function adjustLightness(float $percent): HslColor
+    {
+        [$h, $s, $l] = $this->toHsl()->getArrayValueColor();
+
+        $l = max(0, min(100, $l + $percent));
+
+        return new HslColor([$h, $s, $l]);
+    }
+
+    /**
+     * Adjust the saturation by a percentage.
+     *
+     * @param  float  $percent  Positive to saturate, negative to desaturate.
+     */
+    public function adjustSaturation(float $percent): HslColor
+    {
+        [$h, $s, $l] = $this->toHsl()->getArrayValueColor();
+
+        $s = max(0, min(100, $s + $percent));
+
+        return new HslColor([$h, $s, $l]);
+    }
+
+    /**
+     * Increase the lightness (make brighter).
+     */
+    public function lighter(float $amount = 10): HslColor
+    {
+        return $this->adjustLightness($amount);
+    }
+
+    /**
+     * Decrease the lightness (make darker).
+     */
+    public function darker(float $amount = 10): HslColor
+    {
+        return $this->adjustLightness(-$amount);
+    }
+
+    /**
+     * Increase the saturation.
+     */
+    public function saturate(float $amount = 10): HslColor
+    {
+        return $this->adjustSaturation($amount);
+    }
+
+    /**
+     * Decrease the saturation.
+     */
+    public function desaturate(float $amount = 10): HslColor
+    {
+        return $this->adjustSaturation(-$amount);
+    }
+}

--- a/tests/Concerns/AdjustsColorValuesTest.php
+++ b/tests/Concerns/AdjustsColorValuesTest.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+use Tomloprod\Colority\Colors\HexColor;
+use Tomloprod\Colority\Colors\HslColor;
+use Tomloprod\Colority\Colors\RgbColor;
+
+test('adjustLightness() increases lightness', function (): void {
+    $color = new HslColor('hsl(200, 50, 50)');
+
+    $lighter = $color->adjustLightness(20);
+
+    expect($lighter)->toBeInstanceOf(HslColor::class);
+    expect($lighter->getArrayValueColor()[2])->toBe(70.0);
+});
+
+test('adjustLightness() decreases lightness', function (): void {
+    $color = new HslColor('hsl(200, 50, 50)');
+
+    $darker = $color->adjustLightness(-20);
+
+    expect($darker->getArrayValueColor()[2])->toBe(30.0);
+});
+
+test('adjustLightness() clamps to 0', function (): void {
+    $color = new HslColor('hsl(200, 50, 10)');
+
+    $darker = $color->adjustLightness(-50);
+
+    expect($darker->getArrayValueColor()[2])->toBe(0.0);
+});
+
+test('adjustLightness() clamps to 100', function (): void {
+    $color = new HslColor('hsl(200, 50, 90)');
+
+    $lighter = $color->adjustLightness(50);
+
+    expect($lighter->getArrayValueColor()[2])->toBe(100.0);
+});
+
+test('adjustSaturation() increases saturation', function (): void {
+    $color = new HslColor('hsl(200, 50, 50)');
+
+    $saturated = $color->adjustSaturation(20);
+
+    expect($saturated->getArrayValueColor()[1])->toBe(70.0);
+});
+
+test('adjustSaturation() decreases saturation', function (): void {
+    $color = new HslColor('hsl(200, 50, 50)');
+
+    $desaturated = $color->adjustSaturation(-20);
+
+    expect($desaturated->getArrayValueColor()[1])->toBe(30.0);
+});
+
+test('adjustSaturation() clamps to 0', function (): void {
+    $color = new HslColor('hsl(200, 10, 50)');
+
+    $desaturated = $color->adjustSaturation(-50);
+
+    expect($desaturated->getArrayValueColor()[1])->toBe(0.0);
+});
+
+test('adjustSaturation() clamps to 100', function (): void {
+    $color = new HslColor('hsl(200, 90, 50)');
+
+    $saturated = $color->adjustSaturation(50);
+
+    expect($saturated->getArrayValueColor()[1])->toBe(100.0);
+});
+
+test('lighter() increases lightness by default amount', function (): void {
+    $color = new HslColor('hsl(200, 50, 50)');
+
+    $lighter = $color->lighter();
+
+    expect($lighter->getArrayValueColor()[2])->toBe(60.0);
+});
+
+test('darker() decreases lightness by default amount', function (): void {
+    $color = new HslColor('hsl(200, 50, 50)');
+
+    $darker = $color->darker();
+
+    expect($darker->getArrayValueColor()[2])->toBe(40.0);
+});
+
+test('saturate() increases saturation by default amount', function (): void {
+    $color = new HslColor('hsl(200, 50, 50)');
+
+    $saturated = $color->saturate();
+
+    expect($saturated->getArrayValueColor()[1])->toBe(60.0);
+});
+
+test('desaturate() decreases saturation by default amount', function (): void {
+    $color = new HslColor('hsl(200, 50, 50)');
+
+    $desaturated = $color->desaturate();
+
+    expect($desaturated->getArrayValueColor()[1])->toBe(40.0);
+});
+
+test('methods return HslColor when called on any color type', function (): void {
+    $hexColor = new HexColor('#808080');
+    $rgbColor = new RgbColor('rgb(128, 128, 128)');
+    $hslColor = new HslColor('hsl(200, 50, 50)');
+
+    expect($hexColor->lighter())->toBeInstanceOf(HslColor::class);
+    expect($rgbColor->darker())->toBeInstanceOf(HslColor::class);
+    expect($hslColor->saturate())->toBeInstanceOf(HslColor::class);
+});
+
+test('methods preserve hue', function (): void {
+    $color = new HslColor('hsl(200, 50, 50)');
+
+    expect($color->lighter()->getArrayValueColor()[0])->toBe(200.0);
+    expect($color->darker()->getArrayValueColor()[0])->toBe(200.0);
+    expect($color->saturate()->getArrayValueColor()[0])->toBe(200.0);
+    expect($color->desaturate()->getArrayValueColor()[0])->toBe(200.0);
+});


### PR DESCRIPTION
- Add `AdjustsColorValues` trait with `lighter()`, `darker()`, `saturate()`, `desaturate()`
- Add `adjustLightness()` and `adjustSaturation()` for direct percentage control